### PR TITLE
feat: add metrics and collectionPeriodCount params

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Fetches CrUX API using [`queryRecord options`](https://developer.chrome.com/docs
 
 - _queryOptions.url_ or _queryOptions.origin_ (**required**) – the main identifier for a record lookup;
 - _queryOptions.formFactor_ (optional, defaults to all form factors) - the form factor dimension: `PHONE` | `DESKTOP` | `TABLET`.
+- _queryOptions.metrics_ (optional, defaults to all metrics) - an array of metric keys specifying which metrics to return;
 - _queryOptions.collectionPeriodCount_ (optional, default is 25) - the number of collection periods to return between 1 and 40
 
 Returns a Promise with a raw [`queryRecord` response](https://developer.chrome.com/docs/crux/api/#response-body) or `null` when the data is not found.

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,8 @@ const maxRetryTimeout = 60 * 1000 // 60s
 
 /**
  * @typedef {{ key: string, fetch?: function }} CreateOptions
- * @typedef {{ url?: string, origin?: string, formFactor?: FormFactor }} QueryRecordOptions
+ * @typedef {{ url?: string, origin?: string, formFactor?: FormFactor, metrics?: string[] }} QueryRecordOptions
+ * @typedef { QueryRecordOptions & { collectionPeriodCount?: number }} QueryHistoryRecordOptions
  * @typedef {'ALL_FORM_FACTORS' | 'PHONE' | 'DESKTOP' | 'TABLET'} FormFactor
  * @typedef {{ percentiles: { p75: number } }} PercentileValue
  * @typedef {{ histogram: { start: number | string, end: number | string, density: number }[], percentiles: { p75: number | string } }} MetricValue
@@ -94,7 +95,7 @@ export function createQueryRecord(createOptions) {
   return createQueryCruxApi({ ...createOptions, api: 'record' })
 }
 
-/** @param {CreateOptions} createOptions @return {function(QueryRecordOptions): Promise<HistoryResponse | null>} */
+/** @param {CreateOptions} createOptions @return {function(QueryHistoryRecordOptions): Promise<HistoryResponse | null>} */
 export function createQueryHistoryRecord(createOptions) {
   return createQueryCruxApi({ ...createOptions, api: 'history' })
 }
@@ -113,7 +114,7 @@ function createQueryCruxApi(createOptions) {
   return queryCruxApi
 
   /**
-   * @param {QueryRecordOptions} queryOptions
+   * @param {QueryRecordOptions | QueryHistoryRecordOptions} queryOptions
    * @return {Promise<any | null>}
    */
 

--- a/test/index.js
+++ b/test/index.js
@@ -8,21 +8,32 @@ const key = process.env.CRUX_KEY || 'no-key'
 
 test('createQueryRecord', async (t) => {
   const queryRecord = createQueryRecord({ key, fetch })
-  const json1 = await queryRecord({ url: 'https://github.com/', formFactor: 'DESKTOP' })
+  const json1 = await queryRecord({
+    url: 'https://github.com/',
+    formFactor: 'DESKTOP',
+    metrics: ['cumulative_layout_shift'],
+  })
 
   t.is(json1?.record.key.url, 'https://github.com/')
   t.is(json1?.record.key.formFactor, 'DESKTOP')
+  t.is(Object.keys(json1?.record.metrics ?? {}).length, 1)
 })
 
 test('createQueryHistoryRecord', async (t) => {
   const queryHistory = createQueryHistoryRecord({ key, fetch })
-  const json1 = await queryHistory({ url: 'https://github.com/', formFactor: 'DESKTOP' })
+  const json1 = await queryHistory({
+    url: 'https://github.com/',
+    formFactor: 'DESKTOP',
+    metrics: ['cumulative_layout_shift'],
+    collectionPeriodCount: 20,
+  })
 
   t.is(json1?.record.key.url, 'https://github.com/')
   t.is(json1?.record.key.formFactor, 'DESKTOP')
-  t.is(json1?.record.collectionPeriods.length, 25)
+  t.is(Object.keys(json1?.record.metrics ?? {}).length, 1)
+  t.is(json1?.record.collectionPeriods.length, 20)
   t.is(json1?.record.metrics.cumulative_layout_shift?.histogramTimeseries.length, 3)
-  t.is(json1?.record.metrics.cumulative_layout_shift?.histogramTimeseries[0]?.densities.length, 25)
+  t.is(json1?.record.metrics.cumulative_layout_shift?.histogramTimeseries[0]?.densities.length, 20)
 })
 
 test('normalizeUrl', async (t) => {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,7 @@
 /**
  * @typedef {{ key: string, fetch?: function }} CreateOptions
- * @typedef {{ url?: string, origin?: string, formFactor?: FormFactor }} QueryRecordOptions
+ * @typedef {{ url?: string, origin?: string, formFactor?: FormFactor, metrics?: string[] }} QueryRecordOptions
+ * @typedef { QueryRecordOptions & { collectionPeriodCount?: number }} QueryHistoryRecordOptions
  * @typedef {'ALL_FORM_FACTORS' | 'PHONE' | 'DESKTOP' | 'TABLET'} FormFactor
  * @typedef {{ percentiles: { p75: number } }} PercentileValue
  * @typedef {{ histogram: { start: number | string, end: number | string, density: number }[], percentiles: { p75: number | string } }} MetricValue
@@ -87,8 +88,8 @@
  */
 /** @param {CreateOptions} createOptions @return {function(QueryRecordOptions): Promise<SuccessResponse | null>} */
 export function createQueryRecord(createOptions: CreateOptions): (arg0: QueryRecordOptions) => Promise<SuccessResponse | null>;
-/** @param {CreateOptions} createOptions @return {function(QueryRecordOptions): Promise<HistoryResponse | null>} */
-export function createQueryHistoryRecord(createOptions: CreateOptions): (arg0: QueryRecordOptions) => Promise<HistoryResponse | null>;
+/** @param {CreateOptions} createOptions @return {function(QueryHistoryRecordOptions): Promise<HistoryResponse | null>} */
+export function createQueryHistoryRecord(createOptions: CreateOptions): (arg0: QueryHistoryRecordOptions) => Promise<HistoryResponse | null>;
 /**
  * Normalize URL to match CrUX API key.
  *
@@ -111,6 +112,10 @@ export type QueryRecordOptions = {
     url?: string;
     origin?: string;
     formFactor?: FormFactor;
+    metrics?: string[];
+};
+export type QueryHistoryRecordOptions = QueryRecordOptions & {
+    collectionPeriodCount?: number;
 };
 export type FormFactor = "ALL_FORM_FACTORS" | "PHONE" | "DESKTOP" | "TABLET";
 export type PercentileValue = {


### PR DESCRIPTION
Added `metrics` parameter to `QueryRecordOptions`.
Introduced a `QueryRecordHistoryOptions` type extending `QueryRecordOptions` with `collectionPeriodCount` parameter.
Updated tests and the README.

Fix #7